### PR TITLE
refactor: sort themes from light to dark

### DIFF
--- a/src/Map/Map.tsx
+++ b/src/Map/Map.tsx
@@ -28,18 +28,6 @@ const Map = (props: MapProps): JSX.Element => {
     const availableTileSets: TileSet[] = [
         {
             id: 1,
-            value: 'carto-dark',
-            name: 'Dark',
-            attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> &copy; <a href="http://cartodb.com/attributions">CartoDB</a>',
-            url: 'https://cartodb-basemaps-{s}.global.ssl.fastly.net/dark_all/{z}/{x}/{y}.png',
-            planeIcon: PlaneCyan,
-            planeIconHighlight: PlaneBlue,
-            departureIcon: DepartureWhite,
-            arrivalIcon: ArrivalWhite,
-            previewImageUrl: CartoDarkPreview,
-        },
-        {
-            id: 2,
             value: 'carto-light',
             name: 'Light',
             attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> &copy; <a href="http://cartodb.com/attributions">CartoDB</a>',
@@ -51,7 +39,7 @@ const Map = (props: MapProps): JSX.Element => {
             previewImageUrl: CartoLightPreview,
         },
         {
-            id: 3,
+            id: 2,
             value: 'osm',
             name: 'Open Street Map',
             attribution: '&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors',
@@ -61,6 +49,18 @@ const Map = (props: MapProps): JSX.Element => {
             departureIcon: DepartureGray,
             arrivalIcon: ArrivalGray,
             previewImageUrl: OsmPreview,
+        },
+        {
+            id: 3,
+            value: 'carto-dark',
+            name: 'Dark',
+            attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> &copy; <a href="http://cartodb.com/attributions">CartoDB</a>',
+            url: 'https://cartodb-basemaps-{s}.global.ssl.fastly.net/dark_all/{z}/{x}/{y}.png',
+            planeIcon: PlaneCyan,
+            planeIconHighlight: PlaneBlue,
+            departureIcon: DepartureWhite,
+            arrivalIcon: ArrivalWhite,
+            previewImageUrl: CartoDarkPreview,
         }
     ];
 


### PR DESCRIPTION
Sorts themes light to dark so that the default light theme is what is presented to the user first. 

Screenshot:
![image](https://user-images.githubusercontent.com/30361843/109027518-7ecd2180-7686-11eb-81b1-bf9c5c3a56f2.png)
