### PR TITLE
fix: Adjusting styling on the popup in FlightMarker.tsx for better spacing and scaling

### DIFF
--- a/src/Map/FlightMarker.tsx
+++ b/src/Map/FlightMarker.tsx
@@ -96,9 +96,9 @@ const FlightMarker = (props: FlightMarkerProps): JSX.Element => {
                 onOpen={() => (props.onPopupOpen ? props.onPopupOpen() : {})}
                 onClose={() => (props.onPopupClose ? props.onPopupClose() : {})}
             >
-                <h1>
+                <h1 style={styles['popup-header-text-content']}>
                     Flight
-                    {connection.flight}
+                    {": " + connection.flight}
                 </h1>
                 {
                     (connection.origin && connection.destination)
@@ -114,18 +114,30 @@ const FlightMarker = (props: FlightMarkerProps): JSX.Element => {
                         )
                         : ''
                 }
-                <p>
+                <p style={styles["popup-paragraph-text-content"]}>
                     Aircraft:
-                    {connection.aircraftType}
+                    {" " + connection.aircraftType}
                 </p>
-                <p>
+                <p style={styles["popup-paragraph-text-content"]}>
                     Altitude:
-                    {connection.trueAltitude}
+                    {" " + connection.trueAltitude}
                     ft
                 </p>
             </Popup>
         </Marker>
     );
+    
+};
+
+const styles = {
+    "popup-header-text-content": {
+        "font-size": "200%",
+        "display": "block",
+      },
+      "popup-paragraph-text-content": {
+        "font-size": "125%",
+        "display": "block",
+      }
 };
 
 export default FlightMarker;

--- a/src/Map/FlightMarker.tsx
+++ b/src/Map/FlightMarker.tsx
@@ -133,10 +133,12 @@ const styles = {
     "popup-header-text-content": {
         "font-size": "200%",
         "display": "block",
+        "overflow-wrap": "break-word"
       },
       "popup-paragraph-text-content": {
         "font-size": "125%",
         "display": "block",
+        "overflow-wrap": "break-word"
       }
 };
 


### PR DESCRIPTION
resolves #12 
Old UI shown [here](https://github.com/flybywiresim/react-components/issues/12)

Adjusted UI looks like this: 
![image](https://github.com/flybywiresim/react-components/assets/81841655/10bfe5ba-b74d-41dd-9b48-82ae87d3e425)

I'm certainly no CSS wizard so let me know if there's a better way to do this but I think this adjustment is much better looking. 

